### PR TITLE
[playwright] support proxy certificates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ Codex est invité à contribuer à l'amélioration et au développement de cette
 
 ```
 
-scrapping/
+scraping/
 ├── main.py                  # Point d’entrée de l’application
 ├── requirements.txt         # Dépendances Python
 ├── .env                     # Variables sensibles (API keys)
@@ -47,9 +47,9 @@ scrapping/
 ├── logs/                    # Logs d’exécution
 │   └── prospection.log
 │
-├── tests/                   # Tests manuels
-│   ├── test\_facebook.py
-│   └── test\_instagram.py
+├── tests/                   # Tests unitaires
+│   ├── test\_db.py
+│   └── test\_extract_socials.py
 │
 ├── README.md
 └── AGENTS.md
@@ -103,10 +103,10 @@ pip install ruff
 ruff check .
 ```
 
-### Tests (manuels pour l’instant)
+### Tests
 
 ```bash
-python tests/test_instagram.py
+pytest -q
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -84,6 +84,9 @@ prospection-bretagne/
 git clone https://github.com/votre-user/prospection-bretagne.git
 cd prospection-bretagne
 pip install -r requirements.txt
+playwright install
+# si les navigateurs ne se lancent pas :
+# playwright install-deps
 ```
 
 Configurer le bot Telegram via `.env` :
@@ -103,6 +106,14 @@ python main.py
 Depuis Telegram :
 ```bash
 /entreprises restauration Rennes
+```
+
+## ✅ Tests
+
+Lancer tous les tests unitaires :
+
+```bash
+pytest -q
 ```
 
 ## 🗺️ Roadmap MVP

--- a/scraping/social_playwright.py
+++ b/scraping/social_playwright.py
@@ -8,7 +8,9 @@ import glob
 def scrape_instagram_profile(url, storage_path="cookie/ig_auth.json"):
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
-        context = browser.new_context(storage_state=storage_path)
+        context = browser.new_context(
+            storage_state=storage_path, ignore_https_errors=True
+        )
         page = context.new_page()
 
         try:
@@ -83,7 +85,9 @@ def scrape_facebook_page(url, storage_path="cookie/fb_auth.json", debug=False):
 
     with sync_playwright() as p:
         browser = p.chromium.launch(headless=True)
-        context = browser.new_context(storage_state=storage_path)
+        context = browser.new_context(
+            storage_state=storage_path, ignore_https_errors=True
+        )
         page = context.new_page()
 
         try:


### PR DESCRIPTION
## Summary
- install browsers for Playwright and ignore HTTPS errors
- update README with Playwright setup and test instructions
- sync AGENTS guide with current repo layout and pytest usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685355040be0832fa1c0f38aae71aca2