### PR TITLE
Improve logging and bypass HTTPS errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -51,10 +51,10 @@ def run_pipeline(keyword="restauration", city="Rennes", target_count=5):
     save_leads(results)
 
     for res in results:
-        print("✅ Entreprise trouvée :")
+        logger.info("✅ Entreprise trouvée :")
         for k, v in res.items():
-            print(f"  {k}: {v}")
-        print("-----")
+            logger.info(f"  {k}: {v}")
+        logger.info("-----")
 
     logger.info("🌐 Scraping des sites web pour extraire les réseaux sociaux et emails")
 

--- a/scraping/save_facebook_session.py
+++ b/scraping/save_facebook_session.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import sync_playwright
+from utils.logger import logger
 
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=False)
@@ -7,16 +8,16 @@ with sync_playwright() as p:
 
     # Accès à la page de login Facebook
     page.goto("https://www.facebook.com/login")
-    print("🔐 Connecte-toi manuellement dans le navigateur ouvert...")
+    logger.info("🔐 Connecte-toi manuellement dans le navigateur ouvert...")
 
     # Attente que tu sois sur la page d'accueil après login
     try:
         page.wait_for_url("https://www.facebook.com/", timeout=120000)
-    except:
-        print("⚠️ Timeout : tu n'es pas resté(e) sur la page Facebook assez longtemps.")
+    except Exception:
+        logger.warning("⚠️ Timeout : tu n'es pas resté(e) sur la page Facebook assez longtemps.")
 
     # Sauvegarde de l'état de session
     context.storage_state(path="cookie/fb_auth.json")
-    print("✅ Session Facebook sauvegardée dans cookie/fb_auth.json")
+    logger.info("✅ Session Facebook sauvegardée dans cookie/fb_auth.json")
 
     browser.close()

--- a/scraping/save_instagram_session.py
+++ b/scraping/save_instagram_session.py
@@ -1,4 +1,5 @@
 from playwright.sync_api import sync_playwright
+from utils.logger import logger
 
 with sync_playwright() as p:
     browser = p.chromium.launch(headless=False)
@@ -7,12 +8,12 @@ with sync_playwright() as p:
 
     # Accès à la page de login Instagram
     page.goto("https://www.instagram.com/accounts/login/")
-    print("🔐 Connecte-toi manuellement dans le navigateur lancé...")
+    logger.info("🔐 Connecte-toi manuellement dans le navigateur lancé...")
 
     # Attendre que tu sois connecté
     page.wait_for_url("https://www.instagram.com/", timeout=120000)  # 2 minutes max
 
     # Sauvegarde du contexte une fois connecté
     context.storage_state(path="cookie/ig_auth.json")
-    print("✅ Session Instagram sauvegardée dans cookie/ig_auth.json")
+    logger.info("✅ Session Instagram sauvegardée dans cookie/ig_auth.json")
     browser.close()


### PR DESCRIPTION
## Summary
- adjust log calls in the main pipeline
- switch Facebook/Instagram session helpers to use logger
- update social scraping to use logger and ignore TLS errors

## Testing
- `python - <<'EOF'
from main import run_pipeline
run_pipeline(target_count=1)
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68559ba1cce0832f94f15084b67ceb00