### PR TITLE
Fix Instagram scraping and add pytest suite

### DIFF
--- a/tests/test_extract_socials.py
+++ b/tests/test_extract_socials.py
@@ -1,0 +1,28 @@
+from scraping.extract_socials import extract_infos_from_site
+import requests
+
+class DummyResponse:
+    def __init__(self, text):
+        self.text = text
+    def raise_for_status(self):
+        pass
+
+
+def test_extract_infos_from_site(monkeypatch):
+    html = """
+        <html>
+            <body>
+                <a href='https://facebook.com/testpage'>fb</a>
+                <a href='https://www.instagram.com/test/'>ig</a>
+                <a href='mailto:contact@example.com'>email</a>
+            </body>
+        </html>
+    """
+    def mock_get(url, timeout=8):
+        return DummyResponse(html)
+    monkeypatch.setattr(requests, "get", mock_get)
+    infos = extract_infos_from_site("https://example.com")
+    champs = {i["champ"] for i in infos}
+    assert "facebook" in champs
+    assert "instagram" in champs
+    assert "email" in champs

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,11 @@
+import pytest
+from utils.helpers import is_valid_url
+
+@pytest.mark.parametrize("url,expected", [
+    ("https://example.com", True),
+    ("http://example.com", True),
+    ("ftp://example.com", False),
+    ("not a url", False),
+])
+def test_is_valid_url(url, expected):
+    assert is_valid_url(url) is expected

--- a/tests/test_search_google.py
+++ b/tests/test_search_google.py
@@ -1,0 +1,42 @@
+import os
+from scraping.search_google import search_google_places
+import requests
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        pass
+
+
+def test_search_google_places(monkeypatch):
+    os.environ['GOOGLE_PLACES_API_KEY'] = 'dummy'
+
+    calls = []
+    def mock_get(url, params=None):
+        calls.append(url)
+        if 'textsearch' in url:
+            return DummyResp({'results': [{'place_id': 'abc123'}]})
+        else:
+            return DummyResp({'result': {'name': 'Test',
+                                        'formatted_address': 'Add',
+                                        'formatted_phone_number': '123',
+                                        'website': 'https://example.com',
+                                        'rating': 4.5,
+                                        'user_ratings_total': 10,
+                                        'types': ['type'],
+                                        'url': 'maps_url',
+                                        'opening_hours': {'open_now': True, 'weekday_text': []},
+                                        'editorial_summary': {'overview': 'ok'},
+                                        'reviews': [],
+                                        'price_level': 2,
+                                        'photos': []}})
+    monkeypatch.setattr(requests, 'get', mock_get)
+    leads = search_google_places('foo', 'bar', max_results=1)
+    assert len(leads) == 1
+    lead = leads[0]
+    assert lead['place_id'] == 'abc123'
+    assert lead['nom'] == 'Test'
+    assert lead['site'] == 'https://example.com'

--- a/tests/test_social_playwright.py
+++ b/tests/test_social_playwright.py
@@ -1,0 +1,31 @@
+import json
+import os
+from scraping.social_playwright import scrape_instagram_profile
+import requests
+
+class DummyResp:
+    def __init__(self, data):
+        self._data = data
+    def json(self):
+        return self._data
+    def raise_for_status(self):
+        pass
+
+
+def test_scrape_instagram_profile(tmp_path, monkeypatch):
+    # create fake cookie file
+    cookie = {"cookies": [{"name": "sessionid", "value": "x", "domain": ".instagram.com", "path": "/"}]}
+    cookie_file = tmp_path / "ig.json"
+    cookie_file.write_text(json.dumps(cookie))
+
+    def mock_get(url, headers=None, cookies=None, timeout=15):
+        assert "web_profile_info" in url
+        return DummyResp({"data": {"user": {
+            "edge_followed_by": {"count": 5},
+            "edge_follow": {"count": 2},
+            "edge_owner_to_timeline_media": {"count": 7}
+        }}})
+
+    monkeypatch.setattr(requests, "get", mock_get)
+    res = scrape_instagram_profile("https://www.instagram.com/test/", storage_path=str(cookie_file))
+    assert res == {"followers": 5, "following": 2, "posts": 7}


### PR DESCRIPTION
## Summary
- rewrite Instagram scraper to use API with saved cookies
- add pytest suite covering helpers and scraping modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855cfdf1458832fb4d54558d0145511